### PR TITLE
Convert 2 missed str() calls to bytes(). Helps with #9.

### DIFF
--- a/usbrply.py
+++ b/usbrply.py
@@ -856,7 +856,7 @@ if __name__ == "__main__":
                 comment("WARNING: remaining bytes %d != expected payload out bytes %d" % (len(dat_cur), self.urb.data_length))
                 hexdump(dat_cur, "  ")
                 #raise Exception('See above')
-            pending.m_data_out = str(dat_cur)
+            pending.m_data_out = bytes(dat_cur)
         
         pending.m_ctrl = ctrl
         pending.packet_number = self.pktn_str()
@@ -1010,7 +1010,7 @@ if __name__ == "__main__":
                 comment("WARNING: remaining bytes %d != expected payload out bytes %d" % (len(dat_cur), self.urb.data_length))
                 hexdump(dat_cur, "  ")
                 #raise Exception('See above')
-            pending.m_data_out = str(dat_cur)
+            pending.m_data_out = bytes(dat_cur)
 
         
         pending.packet_number = self.pktn_str()


### PR DESCRIPTION
Hi @JohnDMcMaster,

when rebasing my custom parser on top of already submitted Python3 fixes, I realized that I missed 2 str() invocations in 5750442a528e8ac2a16f37aad329efcbd8846ddc. Fixing that here. Sorry for noise.