### PR TITLE
setup.py: don't forget to install packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 import shutil
 
 
@@ -33,6 +33,7 @@ setup(
     license="BSD",
     keywords="libusb pcap",
     url='https://github.com/JohnDMcMaster/usbrply',
+    packages=find_packages(),
     scripts=scripts_dist,
     install_requires=[
         #'pcap',


### PR DESCRIPTION
Hi John,

this is a lame attempt to fix #32. I don't have full confidence that it does the trick, because my system is Python3 and the mainline usbrply is broken for me due to #9. But I have some hope that my patch makes it better.

Please, don't merge until somebody confirms that it resolved the issue for them.