### PR TITLE
Gh61

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -62,7 +62,7 @@ class TestCase(unittest.TestCase):
         Not exactly sure what this is but its at the beginning of my test capture
         Normally there?
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/win_setup_pipes.pcapng",
                                  argsj=self.argsj),
@@ -79,7 +79,7 @@ class TestCase(unittest.TestCase):
         """
         Verify bulk out parses on Windows
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/win_setup_bulk-out.pcapng",
                                  argsj=self.argsj),
@@ -89,7 +89,7 @@ class TestCase(unittest.TestCase):
         """
         Verify control in parses on Windows
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/win_setup_control-in.pcapng",
                                  argsj=self.argsj),
@@ -99,7 +99,7 @@ class TestCase(unittest.TestCase):
         """
         Verify control out parses on Windows
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/win_setup_control-out.pcapng",
                                  argsj=self.argsj),
@@ -119,7 +119,7 @@ class TestCase(unittest.TestCase):
         """
         Verify control in parses on Linux
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/lin_setup_control-in.pcapng",
                                  argsj=self.argsj),
@@ -129,11 +129,22 @@ class TestCase(unittest.TestCase):
         """
         Verify control out parses on Linux
         """
-        usbrply.printers.run("json",
+        usbrply.printers.run("libusb-py",
                              usbrply.parsers.pcap2json(
                                  "test/data/lin_setup_control-out.pcapng",
                                  argsj=self.argsj),
                              argsj=self.argsj)
+
+    def test_lin_interrupt_out(self):
+        """
+        Verify interrupt out parses on Linux
+        """
+        usbrply.printers.run("libusb-py",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/lin_interrupt_out.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
 
 
 if __name__ == "__main__":

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -25,27 +25,6 @@ class TestCase(unittest.TestCase):
         """Call after every test case."""
         printer.print_file.close()
 
-    def test_parse_win_pcap(self):
-        """Windows .pcap parse test"""
-        parsers.jgen2j(
-            usbrply.parsers.pcap2json("test/data/win1.pcapng",
-                                      argsj=self.argsj))
-
-    def test_parse_lin_pcap(self):
-        """Linux .pcap parse test"""
-        parsers.jgen2j(
-            usbrply.parsers.pcap2json("test/data/lin1.pcapng",
-                                      argsj=self.argsj))
-
-    def test1(self):
-        return
-        j = parsers.jgen2j(
-            usbrply.parsers.pcap2json("test/data/win1.pcapng",
-                                      argsj=self.argsj))
-        for d in j["data"]:
-            if d["type"] == "controlRead":
-                print(d)
-
     def test_print_json(self):
         usbrply.printers.run("json",
                              usbrply.parsers.pcap2json("test/data/lin1.pcapng",
@@ -68,12 +47,11 @@ class TestCase(unittest.TestCase):
     Windows
     """
 
-    def test_win_interrupt(self):
-        usbrply.printers.run("json",
-                             usbrply.parsers.pcap2json(
-                                 "test/data/win_interrupt.pcapng",
-                                 argsj=self.argsj),
-                             argsj=self.argsj)
+    def test_parse_win_pcap(self):
+        """Windows .pcap parse test"""
+        parsers.jgen2j(
+            usbrply.parsers.pcap2json("test/data/win1.pcapng",
+                                      argsj=self.argsj))
 
     def test_win_pipes(self):
         """
@@ -87,6 +65,13 @@ class TestCase(unittest.TestCase):
         usbrply.printers.run("json",
                              usbrply.parsers.pcap2json(
                                  "test/data/win_setup_pipes.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
+    def test_win_interrupt(self):
+        usbrply.printers.run("json",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/win_interrupt.pcapng",
                                  argsj=self.argsj),
                              argsj=self.argsj)
 
@@ -123,6 +108,12 @@ class TestCase(unittest.TestCase):
     """
     Linux
     """
+
+    def test_parse_lin_pcap(self):
+        """Linux .pcap parse test"""
+        parsers.jgen2j(
+            usbrply.parsers.pcap2json("test/data/lin1.pcapng",
+                                      argsj=self.argsj))
 
     def test_lin_control_in(self):
         """

--- a/usbrply/lin_pcap.py
+++ b/usbrply/lin_pcap.py
@@ -595,7 +595,7 @@ class Gen(PcapGen):
             data_size = max_payload_sz
 
         self.output_packet({
-            'type': 'interruptWrite',
+            'type': 'interruptOut',
             'endp': self.submit.urb.endpoint,
             'len': data_size,
             'data': bytes2Hex(self.submit.m_data_out)
@@ -616,7 +616,7 @@ class Gen(PcapGen):
 
         # output below
         self.output_packet({
-            'type': 'interruptRead',
+            'type': 'interruptIn',
             'endp': self.submit.urb.endpoint,
             'len': data_size,
             'data': bytes2Hex(dat_cur)

--- a/usbrply/pyprinter.py
+++ b/usbrply/pyprinter.py
@@ -220,6 +220,7 @@ if __name__ == "__main__":
                 binascii.unhexlify(d["data"])), packet_numbering))
 
         elif d["type"] == "interruptWrite":
+            data_str = bytes2AnonArray(binascii.unhexlify(d["data"]))
             indented("interruptWrite(0x%02X, %s)" % (d["endp"], data_str))
         else:
             if self.verbose:

--- a/usbrply/pyprinter.py
+++ b/usbrply/pyprinter.py
@@ -212,14 +212,14 @@ if __name__ == "__main__":
             # def bulkWrite(self, endpoint, data, timeout=0):
             indented("bulkWrite(0x%02X, %s)" % (d["endp"], data_str))
 
-        elif d["type"] == "interruptRead":
+        elif d["type"] == "interruptIn":
             data_str = "\"\""
             indented("buff = interruptRead(0x%02X, 0x%04X)" %
                      (d["endp"], d["len"]))
             indented("validate_read(%s, buff, \"%s\")" % (bytes2AnonArray(
                 binascii.unhexlify(d["data"])), packet_numbering))
 
-        elif d["type"] == "interruptWrite":
+        elif d["type"] == "interruptOut":
             data_str = bytes2AnonArray(binascii.unhexlify(d["data"]))
             indented("interruptWrite(0x%02X, %s)" % (d["endp"], data_str))
         else:

--- a/usbrply/win_pcap.py
+++ b/usbrply/win_pcap.py
@@ -721,7 +721,7 @@ class Gen(PcapGen):
             data_size = max_payload_sz
 
         self.output_packet({
-            'type': 'interruptWrite',
+            'type': 'interruptOut',
             'endp': self.submit.urb.endpoint,
             'len': data_size,
             'data': bytes2Hex(dat_cur)
@@ -742,7 +742,7 @@ class Gen(PcapGen):
 
         # output below
         self.output_packet({
-            'type': 'interruptRead',
+            'type': 'interruptIn',
             'endp': self.submit.urb.endpoint,
             'len': data_size,
             'data': bytes2Hex(dat_cur)


### PR DESCRIPTION
fixes https://github.com/JohnDMcMaster/usbrply/issues/61

I also changed the internal JSON slightly to use "interruptIn" which appears to be closer to the USB terminology, as opposed to "interruptRead" which is a libusb utility function. Ultimately for most users this is transparent as the python printer will still emit interruptRead()