### PR TITLE
Gh70

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -177,6 +177,28 @@ class TestCase(unittest.TestCase):
             run_printers_json("test/data/win_control-out.pcapng", self.argsj))
         assert packet["data"]
 
+    def test_win_positive_irp_status(self):
+        """
+        Code was failing irp's that had non-0 irp_status
+        While success is typically 0, it's not strictly required
+        """
+        usbrply.printers.run("libusb-py",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/win_irp-status-120.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
+    def test_win_negative_irp_status(self):
+        """
+        FML
+        https://github.com/JohnDMcMaster/usbrply/issues/70
+        """
+        usbrply.printers.run("libusb-py",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/win_irp-status-neg.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
     """
     Linux
     """

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -120,6 +120,18 @@ class TestCase(unittest.TestCase):
                                  argsj=self.argsj),
                              argsj=self.argsj)
 
+        usbrply.printers.run("libusb-py",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/win_abort-pipe.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
+        usbrply.printers.run("libusb-py",
+                             usbrply.parsers.pcap2json(
+                                 "test/data/win_pipe-stall.pcapng",
+                                 argsj=self.argsj),
+                             argsj=self.argsj)
+
     def test_win_interrupt(self):
         usbrply.printers.run("json",
                              usbrply.parsers.pcap2json(

--- a/usbrply/lin_pcap.py
+++ b/usbrply/lin_pcap.py
@@ -314,6 +314,9 @@ class Gen(PcapGen):
                 self.processBulkSubmit(dat_cur)
             elif self.urb.transfer_type == URB_INTERRUPT:
                 self.processInterruptSubmit(dat_cur)
+            else:
+                self.gwarning("packet %s: unhandled type 0x%02X" %
+                              (self.pktn_str(), self.urb.type))
 
         # Should have either generated no comments or attached them
         assert len(self.pcomments) == 0, ("unhandled comment", self.pcomments)

--- a/usbrply/lin_pcap.py
+++ b/usbrply/lin_pcap.py
@@ -240,6 +240,18 @@ class Gen(PcapGen):
 
         self.arg_device = max(self.arg_device, self.urb.device)
 
+    def process_submit(self, dat_cur):
+        # Find the matching submit request
+        if self.urb.transfer_type == URB_CONTROL:
+            self.processControlSubmit(dat_cur)
+        elif self.urb.transfer_type == URB_BULK:
+            self.processBulkSubmit(dat_cur)
+        elif self.urb.transfer_type == URB_INTERRUPT:
+            self.processInterruptSubmit(dat_cur)
+        else:
+            self.gwarning("packet %s: unhandled type 0x%02X" %
+                          (self.pktn_str(), self.urb.type))
+
     def loop_cb(self, caplen, packet, ts):
         packet = bytearray(packet)
         self.cur_packn += 1
@@ -307,19 +319,11 @@ class Gen(PcapGen):
                                       self.urb, dat_cur)
 
         elif self.urb.type == URB_SUBMIT:
-            # Find the matching submit request
-            if self.urb.transfer_type == URB_CONTROL:
-                self.processControlSubmit(dat_cur)
-            elif self.urb.transfer_type == URB_BULK:
-                self.processBulkSubmit(dat_cur)
-            elif self.urb.transfer_type == URB_INTERRUPT:
-                self.processInterruptSubmit(dat_cur)
-            else:
-                self.gwarning("packet %s: unhandled type 0x%02X" %
-                              (self.pktn_str(), self.urb.type))
+            self.process_submit(dat_cur)
 
         # Should have either generated no comments or attached them
-        assert len(self.pcomments) == 0, ("unhandled comment", self.pcomments)
+        assert len(self.pcomments) == 0, ("Packet comments but no packets",
+                                          self.pcomments)
         self.submit = None
         self.urb = None
 
@@ -370,9 +374,9 @@ class Gen(PcapGen):
                 else:
                     self.processInterruptCompleteOut(dat_cur)
             else:
-                if self.verbose:
-                    print("WARNING: unhandled transfer type %s" %
-                          (self.urb.transfer_type == URB_INTERRUPT, ))
+                self.pwarning("unknown transfer type %u" %
+                              self.urb.transfer_type)
+                self.processUnknownComplete(dat_cur)
 
         if self.urb.id in self.pending_complete:
             del self.pending_complete[self.urb.id]
@@ -623,4 +627,9 @@ class Gen(PcapGen):
             'endp': self.submit.urb.endpoint,
             'len': data_size,
             'data': bytes2Hex(dat_cur)
+        })
+
+    def processUnknownComplete(self, dat_cur):
+        self.output_packet({
+            'type': 'unknown',
         })

--- a/usbrply/main.py
+++ b/usbrply/main.py
@@ -54,7 +54,7 @@ def main():
                  '--define',
                  default=False,
                  help='Use defines instead of raw numbers')
-    add_bool_arg(parser, '--halt', default=True, help='Halt on errors')
+    add_bool_arg(parser, '--halt', default=True, help='Halt on bad packets')
     parser.add_argument('--vid',
                         type=str,
                         default="0",

--- a/usbrply/pyprinter.py
+++ b/usbrply/pyprinter.py
@@ -223,8 +223,10 @@ if __name__ == "__main__":
             data_str = bytes2AnonArray(binascii.unhexlify(d["data"]))
             indented("interruptWrite(0x%02X, %s)" % (d["endp"], data_str))
         elif d["type"] == "irpInfo":
-            comment("irpInfo: func %s" %
+            comment("IRP_INFO(): func %s" %
                     (d["submit"]["urb"]["usb_func_str"], ))
+        elif d["type"] == "abortPipe":
+            comment("ABORT_PIPE()")
         else:
             if self.verbose:
                 print("LibusbPyPrinter WARNING: dropping %s" % (d["type"], ))

--- a/usbrply/pyprinter.py
+++ b/usbrply/pyprinter.py
@@ -222,6 +222,9 @@ if __name__ == "__main__":
         elif d["type"] == "interruptOut":
             data_str = bytes2AnonArray(binascii.unhexlify(d["data"]))
             indented("interruptWrite(0x%02X, %s)" % (d["endp"], data_str))
+        elif d["type"] == "irpInfo":
+            comment("irpInfo: func %s" %
+                    (d["submit"]["urb"]["usb_func_str"], ))
         else:
             if self.verbose:
                 print("LibusbPyPrinter WARNING: dropping %s" % (d["type"], ))

--- a/usbrply/usb.py
+++ b/usbrply/usb.py
@@ -6,6 +6,8 @@ URB_ISOCHRONOUS = 0x0
 URB_INTERRUPT = 0x1
 URB_CONTROL = 0x2
 URB_BULK = 0x3
+# Wireshark GUI's name
+USB_IRP_INFO = 0xFE
 '''
 possible event type
 '''


### PR DESCRIPTION
Fixes #70 and #71

I've significantly improved the handling of Windows special packets. I've also added a few test cases with some sample output below

```
$ usbrply test/data/win_abort-pipe.pcapng
...
# Generated from packet 1/2
# ABORT_PIPE()

$ usbrply test/data/win_pipe-stall.pcapng
...
# Generated from packet 1/2
# IRP_INFO(): func SYNC_RESET_PIPE_AND_CLEAR_STALL
```